### PR TITLE
Add support for a connection pool

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,3 +11,5 @@ license: MIT
 dependencies:
   neo4j:
     github: jgaskins/neo4j.cr
+  pool:
+    github: ysbaddaden/pool

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -5,8 +5,7 @@ require "../src/neo4j_model"
 Spec.before_each { detach_all }
 
 def detach_all
-  connection = Neo4j::Bolt::Connection.new(Neo4jModel.settings.neo4j_bolt_url, ssl: false)
-  connection.execute "MATCH (n) DETACH DELETE n"
+  Movie.with_connection(&.execute "MATCH (n) DETACH DELETE n")
 end
 
 class Movie

--- a/src/neo4j/base.cr
+++ b/src/neo4j/base.cr
@@ -1,8 +1,13 @@
 require "neo4j"
 require "uuid"
+require "pool/connection"
 
 module Neo4j
   module Model
+    ConnectionPool = ::ConnectionPool(Bolt::Connection).new do
+      Bolt::Connection.new(Neo4jModel.settings.neo4j_bolt_url, ssl: false)
+    end
+
     def uuid
       @_uuid
     end
@@ -32,8 +37,10 @@ module Neo4j
       # override if you want to use a different label
       class_getter label : String = "{{@type.name}}"
 
-      def self.connection
-        Neo4j::Bolt::Connection.new(Neo4jModel.settings.neo4j_bolt_url, ssl: false)
+      def {{@type.id}}.with_connection
+        ConnectionPool.connection do |connection|
+          yield connection
+        end
       end
 
       def initialize

--- a/src/neo4j/querying.cr
+++ b/src/neo4j/querying.cr
@@ -295,7 +295,7 @@ module Neo4j
           build_cypher_query
 
           start = Time.monotonic
-          result = {{@type.id}}.connection.execute(@cypher_query, @cypher_params)
+          result = {{@type.id}}.with_connection(&.execute(@cypher_query, @cypher_params))
           elapsed_ms = (Time.monotonic - start).milliseconds
           Neo4jModel.settings.logger.debug "Executed query (#{elapsed_ms}ms): #{result.type.inspect}"
 


### PR DESCRIPTION
This keeps us from having to reconnect to the DB on every query, removing the latency cost of repeated TCP handshakes, TLS negotiations, and TCP slow start. It made a huge difference just running the specs against my local Neo4j instance:

### Before

```
➜  neo4j_model.cr git:(master) NEO4J_URL=bolt://neo4j:password@localhost crystal spec
........

Finished in 545.02 milliseconds
8 examples, 0 failures, 0 errors, 0 pending
```

### With this PR

```
➜  neo4j_model.cr git:(connection-pool) ✗ NEO4J_URL=bolt://neo4j:password@localhost crystal spec
........

Finished in 256.88 milliseconds
8 examples, 0 failures, 0 errors, 0 pending
```

It removes the `Model.connection` class method and replaces it with a connection-checkout block for the `ConnectionPool` object:

```crystal
models = Model.with_connection do |conn|
  conn.execute "MATCH (n:{{@type.name}}) RETURN n"
end
```

At the end of the block, the connection is checked back into the connection pool so another fiber can use it immediately. The default capacity for the connection pool is 25, but it will only create them as needed — if you're only ever handling one HTTP request at a time, for example, you'll only have a single connection, but if a second request comes in while the first one's query is still in flight, it'll spin up another connection.

The `pool` shard does allow for assigning the connection to the current fiber, but I don't know if I'd recommend using that functionality. In a web app, the `HTTP::Server::Context` will have a new fiber for every request and then it gets thrown away. Rails, on the other hand, uses a pool of persistent threads, which is why `ActiveRecord::Base.connection` makes sense there. Doing that here might leak connections as each fiber is thrown away.

It's possible that that isn't true and that once the `Neo4j::Bolt::Connection` object goes out of scope and gets GCed its connection will be closed, but even in that case, we'd still be spinning up connections for each request if we used one connection per fiber.